### PR TITLE
feat: add button with link to remote repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,31 @@ Default: `No workspace.`
 -   `{currentline}` will get replaced with the current line number
 -   `{totallines}` will get replaced with the total line number
 </details>
-    
+
+#### **rpc.button.enable**
+
+Enable a button on your presence with a link to the Git repository you're working in.
+
+Default: `false`
+
+#### **rpc.button.activeLabel**
+
+The label to show on the button when the file you are currently editing is located in a Git repository. Set to `null` to disable.
+
+Default: `View Repository`
+
+#### **rpc.button.inactiveLabel**
+
+The label to show on the button when you are not editing a file in a Git repository. Set to `null` to disable.
+
+Default: `null`
+
+#### **rpc.button.inactiveUrl**
+
+The URL of the button when you are not editing a file in a Git repository. Set to `null` to disable.
+
+Default: `null`
+
 ## 👨‍💻 Contributing
 
 To contribute to this repository, feel free to create a new fork of the repository and submit a pull request.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"homepage": "https://github.com/LeonardSSH/coc-discord-rpc#readme",
 	"dependencies": {
 		"bufferutil": "^4.0.3",
-		"discord-rpc": "^3.1.4",
+		"discord-rpc": "^3.2.0",
 		"electron": "^11.2.0",
 		"utf-8-validate": "^5.0.4",
 		"vscode-languageserver-protocol": "^3.16.0",
@@ -55,7 +55,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^11.0.0",
 		"@commitlint/config-conventional": "^11.0.0",
-		"@types/discord-rpc": "^3.0.4",
+		"@types/discord-rpc": "^3.0.5",
 		"@types/node": "^14.14.0",
 		"@types/ws": "^7.2.9",
 		"@typescript-eslint/eslint-plugin": "^4.5.0",
@@ -216,6 +216,26 @@
 					"type": "string",
 					"default": "Idle",
 					"description": "Custom string of the text displaying if you're idle when hovering over the small icon."
+				},
+				"rpc.button.enable": {
+					"type": "boolean",
+					"default": "false",
+					"description": "Enable a button on your presence with a link to the Git repository you're working in."
+				},
+				"rpc.button.activeLabel": {
+					"type": "string",
+					"default": "View Repository",
+					"description": "The label to show on the button when the file you are currently editing is located in a Git repository. Set to null to disable."
+				},
+				"rpc.button.inactiveLabel": {
+					"type": "string",
+					"default": null,
+					"description": "The label to show on the button when you are not editing a file in a Git repository. Set to null to disable. (Disabled by default)"
+				},
+				"rpc.button.inactiveUrl": {
+					"type": "string",
+					"default": null,
+					"description": "The URL of the button when you are not editing a file in a Git repository. Set to null to disable. (Disabled by default)"
 				}
 			}
 		}

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import { Client as RPC, Presence } from 'discord-rpc';
 import { Activity } from './activity';
 import { Listener } from './listener';
 import { logInfo } from './logger';
+import { getGitRepo } from './util';
 
 export class Client implements Disposable {
 	private rpc?: RPC;
@@ -63,6 +64,18 @@ export class Client implements Disposable {
 	public async setActivity(presence: Presence) {
 		if (!this.rpc || !this.ready) {
 			return;
+		}
+
+		const { button } = this.config;
+
+		if (button.enable) {
+			const gitRepo = await getGitRepo();
+
+			if (gitRepo && button.activeLabel) {
+				presence.buttons = [{ label: button.activeLabel, url: gitRepo }];
+			} else if (!gitRepo && button.inactiveLabel && button.inactiveUrl) {
+				presence.buttons = [{ label: button.inactiveLabel, url: button.inactiveUrl }];
+			}
 		}
 
 		await this.rpc.setActivity(presence).catch(() => this.dispose());

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,32 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const asyncExec = promisify(exec);
+
+export async function getGitRepo(): Promise<string | null> {
+	try {
+		const isInit = await asyncExec('git rev-parse --git-dir');
+
+		if (!isInit.stdout.trim()) {
+			return null;
+		}
+
+		const remoteUrl = await asyncExec('git config --get remote.origin.url');
+
+		if (!remoteUrl.stdout) {
+			return null;
+		}
+
+		const matched = /^(?:git@|https?:\/\/)(?<provider>[a-zA-Z_.~-]+\.[a-z]{2,})(?::|\/)(?<user>.*?)\/(?<repo>.*)$/.exec(
+			remoteUrl.stdout.trim()
+		);
+
+		if (!matched || !matched.groups?.provider || !matched.groups?.user || !matched.groups?.repo) {
+			return null;
+		}
+
+		return `https://${matched.groups.provider}/${matched.groups.user}/${matched.groups.repo}`;
+	} catch {
+		return null;
+	}
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": ["src"]
+	"include": ["src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,10 +248,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/discord-rpc@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/discord-rpc/-/discord-rpc-3.0.4.tgz#2b8c380ff17797b1408fd231b3a9944da515c331"
-  integrity sha512-Ee0vt82qcg05OeJrQZ/YN+NQwaBCnAul1rVLYaMLPkwR5f44WC3BpBQNvn5Z3Axu9szaVOHqXEDBI+uAXAiyrg==
+"@types/discord-rpc@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/discord-rpc/-/discord-rpc-3.0.5.tgz#16f03fb6ca9a111e4e1f69571e966d1ddf893160"
+  integrity sha512-rgv9W0XNZt437MoUrQfS6OPjTn1MI3Oix9l5aKyzma5Xf4MAiXbHTPUrL62HlHx6WuFMI58bQpJqoXjz+fHCuQ==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
@@ -1457,10 +1457,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-rpc@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/discord-rpc/-/discord-rpc-3.1.4.tgz#6d449a682e6a0dec4f0444d5f36f9ebfabaccf91"
-  integrity sha512-QaBu+gHica2SzgRAmTpuJ4J8DX9+fDwAqhvaie3hcbkU9WPqewEPh21pWdd/7vTI/JNuapU7PFm2ZKg3BTkbGg==
+discord-rpc@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/discord-rpc/-/discord-rpc-3.2.0.tgz#8da4e01654fce38e959d70b58708c46ae1d6c8fa"
+  integrity sha512-KJv0EVbGMlr04HoG6f5b3wD7X9kSHzQ2Ed2qfHSDvYJ1MkE8RbCQmMcQQrSvAxpfsqZgUjB/bsfi/mjyicCH+A==
   dependencies:
     node-fetch "^2.6.1"
     ws "^7.3.1"


### PR DESCRIPTION
This adds a button with a link to the remote repo of the current workspace. If the workspace is not in a git repo, the button text will change to reflect that. Button visibility and button labels can both be changed.

All major Git hosting providers should work as intended (tested with GitHub, GitLab, Gitea).

**Example with a repo**:
![image](https://user-images.githubusercontent.com/36977340/119582214-3101ab80-bd92-11eb-8fef-dda7b373fcc0.png)
**Example without a repo**:
![image](https://user-images.githubusercontent.com/36977340/119582271-5098d400-bd92-11eb-8fbb-df3a5816e7ab.png)

Changes made:
- Bump version for `discord-rpc` to support buttons
- Add code to set buttons + options
- Updated README.md with new options