### PR TITLE
fix(activity.ts): add condition when diagnostic is undefined

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -176,8 +176,11 @@ export class ActivityController {
 			const workspaceFolderName = workspaceFolder?.name ?? noWorkspaceFound;
 
 			const problemsCount = diagnosticManager.getDiagnostics(document.uri).length;
+
 			const problems = config[CONFIG_KEYS.ShowProblems]
-				? config[CONFIG_KEYS.ProblemsText].replace(REPLACE_KEYS.ProblemsCount, problemsCount.toString())
+				? problemsCount
+					? config[CONFIG_KEYS.ProblemsText].replace(REPLACE_KEYS.ProblemsCount, problemsCount.toString())
+					: ''
 				: '';
 
 			try {


### PR DESCRIPTION
fix #51

There was a problem where (activity.ts:178) could be undefined which cannot be
converted to string. So I added a condition incase it is undefined then set it
to empty string
