### PR TITLE
Improve git URL parsing

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -45,7 +45,9 @@ export async function getGitRepo(): Promise<string | null> {
 
         if (!remoteUrl.stdout) return null;
 
-        return gitUrlParse(remoteUrl.stdout.trim()).toString("https").replace(".git", "");
+        return gitUrlParse(remoteUrl.stdout.trim())
+            .toString("https")
+            .replace(/\.git$/, "");
     } catch {
         return null;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,7 +45,7 @@ export async function getGitRepo(): Promise<string | null> {
 
         if (!remoteUrl.stdout) return null;
 
-        return gitUrlParse(remoteUrl.stdout).toString("https").replace(".git", "");
+        return gitUrlParse(remoteUrl.stdout.trim()).toString("https").replace(".git", "");
     } catch {
         return null;
     }


### PR DESCRIPTION
Trims the whitespace off the git remote URL so `git-url-parse` doesn't throw an error, and prevents `.git` from being removed from the middle of a URL.